### PR TITLE
Avoid unnecessary convert to RGB and allow using image formats different from PNG

### DIFF
--- a/src/pyocr/cuneiform.py
+++ b/src/pyocr/cuneiform.py
@@ -98,9 +98,11 @@ def image_to_string(image, lang=None, builder=None):
         cmd += ["-o", output_file.name]
         cmd += ["-"]  # stdin
 
+        if image.mode != "RGB":
+            image = image.convert("RGB")
+
         img_data = BytesIO()
-        image = image.convert("RGB")
-        image.save(img_data, format="png")
+        image.save(img_data, format=image.format)
 
         proc = subprocess.Popen(cmd,
                                 stdin=subprocess.PIPE,

--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -150,12 +150,13 @@ def detect_orientation(image, lang=None):
     if lang is not None:
         command += ['-l', lang]
 
-    image = image.convert("RGB")
+    if image.mode != "RGB":
+        image = image.convert("RGB")
 
     proc = subprocess.Popen(command, stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.STDOUT)
-    image.save(proc.stdin, format='png')
+    image.save(proc.stdin, format=image.format)
     proc.stdin.close()
     output = proc.stdout.read()
     proc.wait()


### PR DESCRIPTION
the ```image_to_string``` method on ```cuneiform.py``` performs a RGB conversion even if the image is already in the RGB format. I've only added a if statement for checking if we really need to do it.

I've also seen that you use the ```image.save``` from PIL(Pillow) to convert this image into a PNG format regardless of image.format. As Cuneiform can read all image formats that ```ImageMagick.h``` can and Tesseract can read multiple formats too, it seems only fair that developers may be able use different formats too such as ( JPEG, GIF, PNG an so on ).