### PR TITLE
Fix for dev version of tesseract (i.e. 3.05.00dev)

### DIFF
--- a/src/pyocr/libtesseract/__init__.py
+++ b/src/pyocr/libtesseract/__init__.py
@@ -170,6 +170,12 @@ def get_available_languages():
 def get_version():
     version = tesseract_raw.get_version()
     version = version.split(" ", 1)[0]
+    
+    # cut off "dev" string if exists for proper int conversion
+    index = version.find("dev")
+    if index:
+        version = version[:index]
+
     version = version.split(".")
     major = int(version[0])
     minor = int(version[1])


### PR DESCRIPTION
Cut off "dev" suffix from the version string. Otherwise it will fail on int conversion and causes error: ValueError: invalid literal for int() with base 10: '00dev'