### PR TITLE
fixed exception creation in detect_os

### DIFF
--- a/src/pyocr/libtesseract/tesseract_raw.py
+++ b/src/pyocr/libtesseract/tesseract_raw.py
@@ -506,7 +506,7 @@ def detect_os(handle):
         ctypes.pointer(results)
     )
     if not r:
-        raise TesseractError("TessBaseAPIDetectOS() failed")
+        raise TesseractError("detect_orientation failed", "TessBaseAPIDetectOS() failed")
     return {
         "orientation": results.best_orientation_id,
         "confidence": results.best_oconfidence,


### PR DESCRIPTION
Just found this issue, currently the creation of the exception raises the following exception:
`TypeError: __init__() missing 1 required positional argument: 'message'`