### PR TITLE
Ftr minimal digit

### DIFF
--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -347,8 +347,9 @@ class DigitBuilder(TextBuilder):
     string of digits. 
     This string will be the output of the OCR tool, as-is. 
     In other words, the raw text as produced by the tool when the input is
-    assumed to be [0-9.] only. Note that depending on the tool, 
-    some other characters may be included.
+    assumed to be [0-9.] only.
+    image_to_string() raises `NotImplementedError` with tools (Cuneiform)
+    unable to process the input this way.
 
     Warning:
         The returned string is encoded in UTF-8.
@@ -687,8 +688,10 @@ class DigitLineBoxBuilder(LineBoxBuilder):
     If passed to image_to_string(), image_to_string() will return
     an array of LineBox. Each box contains a word recognized in the image
     with nearly only numeric characters [0-9.], depending on the tool.
-
+    `image_to_string` raises NotImplementedError with some tools (Cuneiform)
+    unable to process the input this way.
     """
+
     @staticmethod
     def __str__():
         return "Digit line boxes"

--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -226,7 +226,39 @@ class LineBox(object):
         return (position_hash ^ hash(content) ^ hash(content))
 
 
-class TextBuilder(object):
+class BaseBuilder(object):
+    """
+    Builders format the output of the OCR tools, 
+    and potentially configures the tools.
+    
+    Attributes:
+        file_extensions : File extensions of the output.
+        tesseract_configs : Arguments passed to the Tesseract command line.
+        cuneiform_args : Arguments passed to the Cuneiform command line.
+
+    """
+    def __init__(self, file_extensions, tesseract_configs, cuneiform_args):
+        self.file_extensions = file_extensions
+        self.tesseract_configs = tesseract_configs
+        self.cuneiform_args = cuneiform_args
+
+    def read_file(self, file_descriptor):
+        """
+        Read in the OCR results from `file_descriptor`
+        as an appropriate format.
+
+        """
+        raise NotImplementedError("Implement in subclasses")
+
+    def write_file(self, file_descriptor, output):
+        """
+        Write the `output` to `file_descriptor`.
+        
+        """
+        raise NotImplementedError("Implement in subclasses")
+
+
+class TextBuilder(BaseBuilder):
     """
     If passed to image_to_string(), image_to_string() will return a simple
     string. This string will be the output of the OCR tool, as-is. In other
@@ -234,23 +266,21 @@ class TextBuilder(object):
 
     Warning:
         The returned string is encoded in UTF-8
+
     """
-
-    file_extensions = ["txt"]
-    tesseract_configs = []
-    cuneiform_args = ["-f", "text"]
-
     def __init__(self, tesseract_layout=3, cuneiform_dotmatrix=False,
                  cuneiform_fax=False, cuneiform_singlecolumn=False):
-        self.tesseract_layout = tesseract_layout
-        self.tesseract_configs += ["-psm", str(tesseract_layout)]
+        file_ext = ["txt"]
+        tess_conf = ["-psm", str(tesseract_layout)]
+        cun_arg = ["-f", "text"]
         # Add custom cuneiform parameters if needed
-        if cuneiform_dotmatrix:
-            self.cuneiform_args.append("--dotmatrix")
-        if cuneiform_fax:
-            self.cuneiform_args.append("--fax")
-        if cuneiform_singlecolumn:
-            self.cuneiform_args.append("--singlecolumn")
+        for par, arg in [(cuneiform_dotmatrix, "--dotmatrix"),
+                         (cuneiform_fax, "--fax"),
+                         (cuneiform_singlecolumn, "--singlecolumn")]:
+            if par:
+                cun_arg.append(arg)
+        super(TextBuilder, self).__init__(file_ext, tess_conf, cun_arg)
+        self.tesseract_layout = tesseract_layout
         self.built_text = []
 
     @staticmethod
@@ -473,20 +503,19 @@ class _LineHTMLParser(HTMLParser):
         return "LineHTMLParser"
 
 
-class WordBoxBuilder(object):
+class WordBoxBuilder(BaseBuilder):
     """
     If passed to image_to_string(), image_to_string() will return an array of
     Box. Each box contains a word recognized in the image.
     """
 
-    file_extensions = ["html", "hocr"]
-    tesseract_configs = ['hocr']
-    cuneiform_args = ["-f", "hocr"]
-
     def __init__(self, tesseract_layout=1):
+        file_ext = ["html", "hocr"]
+        tess_conf = ["hocr", "-psm", str(tesseract_layout)]
+        cun_arg = ["-f", "hocr"]
+        super(WordBoxBuilder, self).__init__(file_ext, tess_conf, cun_arg)
         self.word_boxes = []
         self.tesseract_layout = tesseract_layout
-        self.tesseract_configs += ["-psm", str(tesseract_layout)]
 
     def read_file(self, file_descriptor):
         """
@@ -546,20 +575,19 @@ class WordBoxBuilder(object):
         return "Word boxes"
 
 
-class LineBoxBuilder(object):
+class LineBoxBuilder(BaseBuilder):
     """
     If passed to image_to_string(), image_to_string() will return an array of
-    LineBox. Each box contains a word recognized in the image.
+    LineBox. Each box contains a line of text recognized in the image.
     """
 
-    file_extensions = ["html", "hocr"]
-    tesseract_configs = ['hocr']
-    cuneiform_args = ["-f", "hocr"]
-
     def __init__(self, tesseract_layout=1):
+        file_ext = ["html", "hocr"]
+        tess_conf = ["hocr", "-psm", str(tesseract_layout)]
+        cun_arg = ["-f", "hocr"]
+        super(LineBoxBuilder, self).__init__(file_ext, tess_conf, cun_arg)
         self.lines = []
         self.tesseract_layout = tesseract_layout
-        self.tesseract_configs += ["-psm", str(tesseract_layout)]
 
     def read_file(self, file_descriptor):
         """

--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -224,33 +224,7 @@ class LineBox(object):
         return (position_hash ^ hash(content) ^ hash(content))
 
 
-class BaseBuilder(object):
-    """
-    Abstract base class for builders.
-    A builder specifies the expected output format 
-    and some OCR configuration options.
-
-    Arguments:
-        lang --- language of the input. Defaults to None.
-        num_mode --- boolean
-
-    """
-    file_extensions = []
-    tesseract_configs = []
-    cuneiform_args = []
-
-    def __init__(self, lang=None, num_mode=None):
-        self.set_language(lang)
-        self.set_numeric_mode(num_mode)
-
-    def set_language(self, lang):
-        self.lang = lang
-
-    def set_numeric_mode(self, num_mode):
-        self.numeric_mode = num_mode
-
-
-class TextBuilder(BaseBuilder):
+class TextBuilder(object):
     """
     If passed to image_to_string(), image_to_string() will return a simple
     string. This string will be the output of the OCR tool, as-is. In other
@@ -265,9 +239,7 @@ class TextBuilder(BaseBuilder):
     cuneiform_args = ["-f", "text"]
 
     def __init__(self, tesseract_layout=3, cuneiform_dotmatrix=False,
-                 cuneiform_fax=False, cuneiform_singlecolumn=False,
-                 lang=None, num_mode=None):
-        super(TextBuilder, self).__init__(lang, num_mode)
+                 cuneiform_fax=False, cuneiform_singlecolumn=False):
         self.tesseract_layout = tesseract_layout
         self.tesseract_configs += ["-psm", str(tesseract_layout)]
         # Add custom cuneiform parameters if needed
@@ -478,7 +450,7 @@ class _LineHTMLParser(HTMLParser):
         return "LineHTMLParser"
 
 
-class WordBoxBuilder(BaseBuilder):
+class WordBoxBuilder(object):
     """
     If passed to image_to_string(), image_to_string() will return an array of
     Box. Each box contains a word recognized in the image.
@@ -488,8 +460,7 @@ class WordBoxBuilder(BaseBuilder):
     tesseract_configs = ['hocr']
     cuneiform_args = ["-f", "hocr"]
 
-    def __init__(self, tesseract_layout=1, lang=None, num_mode=None):
-        super(WordBoxBuilder, self).__init__(lang, num_mode)
+    def __init__(self, tesseract_layout=1):
         self.word_boxes = []
         self.tesseract_layout = tesseract_layout
         self.tesseract_configs += ["-psm", str(tesseract_layout)]
@@ -552,7 +523,7 @@ class WordBoxBuilder(BaseBuilder):
         return "Word boxes"
 
 
-class LineBoxBuilder(BaseBuilder):
+class LineBoxBuilder(object):
     """
     If passed to image_to_string(), image_to_string() will return an array of
     LineBox. Each box contains a word recognized in the image.
@@ -562,8 +533,7 @@ class LineBoxBuilder(BaseBuilder):
     tesseract_configs = ['hocr']
     cuneiform_args = ["-f", "hocr"]
 
-    def __init__(self, tesseract_layout=1, lang=None, num_mode=None):
-        super(LineBoxBuilder, self).__init__(lang, num_mode)
+    def __init__(self, tesseract_layout=1):
         self.lines = []
         self.tesseract_layout = tesseract_layout
         self.tesseract_configs += ["-psm", str(tesseract_layout)]

--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -224,7 +224,33 @@ class LineBox(object):
         return (position_hash ^ hash(content) ^ hash(content))
 
 
-class TextBuilder(object):
+class BaseBuilder(object):
+    """
+    Abstract base class for builders.
+    A builder specifies the expected output format 
+    and some OCR configuration options.
+
+    Arguments:
+        lang --- language of the input. Defaults to None.
+        num_mode --- boolean
+
+    """
+    file_extensions = []
+    tesseract_configs = []
+    cuneiform_args = []
+
+    def __init__(self, lang=None, num_mode=None):
+        self.set_language(lang)
+        self.set_numeric_mode(num_mode)
+
+    def set_language(self, lang):
+        self.lang = lang
+
+    def set_numeric_mode(self, num_mode):
+        self.numeric_mode = num_mode
+
+
+class TextBuilder(BaseBuilder):
     """
     If passed to image_to_string(), image_to_string() will return a simple
     string. This string will be the output of the OCR tool, as-is. In other
@@ -239,9 +265,11 @@ class TextBuilder(object):
     cuneiform_args = ["-f", "text"]
 
     def __init__(self, tesseract_layout=3, cuneiform_dotmatrix=False,
-                 cuneiform_fax=False, cuneiform_singlecolumn=False):
-        self.tesseract_configs += ["-psm", str(tesseract_layout)]
+                 cuneiform_fax=False, cuneiform_singlecolumn=False,
+                 lang=None, num_mode=None):
+        super(TextBuilder, self).__init__(lang, num_mode)
         self.tesseract_layout = tesseract_layout
+        self.tesseract_configs += ["-psm", str(tesseract_layout)]
         # Add custom cuneiform parameters if needed
         if cuneiform_dotmatrix:
             self.cuneiform_args.append("--dotmatrix")
@@ -450,7 +478,7 @@ class _LineHTMLParser(HTMLParser):
         return "LineHTMLParser"
 
 
-class WordBoxBuilder(object):
+class WordBoxBuilder(BaseBuilder):
     """
     If passed to image_to_string(), image_to_string() will return an array of
     Box. Each box contains a word recognized in the image.
@@ -460,7 +488,8 @@ class WordBoxBuilder(object):
     tesseract_configs = ['hocr']
     cuneiform_args = ["-f", "hocr"]
 
-    def __init__(self, tesseract_layout=1):
+    def __init__(self, tesseract_layout=1, lang=None, num_mode=None):
+        super(WordBoxBuilder, self).__init__(lang, num_mode)
         self.word_boxes = []
         self.tesseract_layout = tesseract_layout
         self.tesseract_configs += ["-psm", str(tesseract_layout)]
@@ -523,7 +552,7 @@ class WordBoxBuilder(object):
         return "Word boxes"
 
 
-class LineBoxBuilder(object):
+class LineBoxBuilder(BaseBuilder):
     """
     If passed to image_to_string(), image_to_string() will return an array of
     LineBox. Each box contains a word recognized in the image.
@@ -533,7 +562,8 @@ class LineBoxBuilder(object):
     tesseract_configs = ['hocr']
     cuneiform_args = ["-f", "hocr"]
 
-    def __init__(self, tesseract_layout=1):
+    def __init__(self, tesseract_layout=1, lang=None, num_mode=None):
+        super(LineBoxBuilder, self).__init__(lang, num_mode)
         self.lines = []
         self.tesseract_layout = tesseract_layout
         self.tesseract_configs += ["-psm", str(tesseract_layout)]

--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -20,6 +20,8 @@ __all__ = [
     'TextBuilder',
     'WordBoxBuilder',
     'LineBoxBuilder',
+    'DigitBuilder',
+    'DigitLineBoxBuilder',
 ]
 
 _XHTML_HEADER = to_unicode("""<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
@@ -282,6 +284,27 @@ class TextBuilder(object):
     @staticmethod
     def __str__():
         return "Raw text"
+
+
+class DigitBuilder(TextBuilder):
+    """
+    If passed to image_to_string(), image_to_string() will return a simple
+    string of digits. 
+    This string will be the output of the OCR tool, as-is. 
+    In other words, the raw text as produced by the tool when the input is
+    assumed to be 0-9 only.
+
+    Warning:
+        The returned string is encoded in UTF-8
+    """
+    @staticmethod
+    def __str__():
+        return "Digits raw text."
+
+    def __init__(self, tesseract_layout=3):
+        super(DigitBuilder, self).__init__(tesseract_layout)
+        self.tesseract_configs.append("digits")
+
 
 
 class _WordHTMLParser(HTMLParser):
@@ -602,3 +625,19 @@ class LineBoxBuilder(object):
     @staticmethod
     def __str__():
         return "Line boxes"
+
+
+class DigitLineBoxBuilder(LineBoxBuilder):
+    """
+    If passed to image_to_string(), image_to_string() will return
+    an array of LineBox. Each box contains a word recognized in the image
+    with only numeric character (0-9).
+
+    """
+    @staticmethod
+    def __str__():
+        return "Digit line boxes"
+
+    def __init__(self, tesseract_layout=1):
+        super(DigitLineBoxBuilder, self).__init__(tesseract_layout)
+        self.tesseract_configs.append("digits")

--- a/src/pyocr/cuneiform.py
+++ b/src/pyocr/cuneiform.py
@@ -89,20 +89,10 @@ def cleanup(filename):
 def image_to_string(image, lang=None, builder=None):
     if builder is None:
         builder = builders.TextBuilder()
-    if lang is not None:
-        if builder.lang is not None:
-            raise ValueError(
-                "Language is set twice, for the builder and in image_to_string"
-            )
-        else:
-            builder.set_language(lang)
-    if builder.numeric_mode:
-        raise NotImplementedError("This option is not available with Cuneiform.")
-
     with temp_file(builder.file_extensions[0]) as output_file:
         cmd = [CUNEIFORM_CMD]
-        if builder.lang is not None:
-            cmd += ["-l", builder.lang]
+        if lang is not None:
+            cmd += ["-l", lang]
         cmd += builder.cuneiform_args
         cmd += ["-o", output_file.name]
         cmd += ["-"]  # stdin

--- a/src/pyocr/cuneiform.py
+++ b/src/pyocr/cuneiform.py
@@ -89,6 +89,10 @@ def cleanup(filename):
 def image_to_string(image, lang=None, builder=None):
     if builder is None:
         builder = builders.TextBuilder()
+    if "digits" in builder.tesseract_configs:
+        raise NotImplementedError(
+            "Numerical only : This option is not available with Cuneiform"
+        )
     with temp_file(builder.file_extensions[0]) as output_file:
         cmd = [CUNEIFORM_CMD]
         if lang is not None:

--- a/src/pyocr/cuneiform.py
+++ b/src/pyocr/cuneiform.py
@@ -89,11 +89,20 @@ def cleanup(filename):
 def image_to_string(image, lang=None, builder=None):
     if builder is None:
         builder = builders.TextBuilder()
+    if lang is not None:
+        if builder.lang is not None:
+            raise ValueError(
+                "Language is set twice, for the builder and in image_to_string"
+            )
+        else:
+            builder.set_language(lang)
+    if builder.numeric_mode:
+        raise NotImplementedError("This option is not available with Cuneiform.")
 
     with temp_file(builder.file_extensions[0]) as output_file:
         cmd = [CUNEIFORM_CMD]
-        if lang is not None:
-            cmd += ["-l", lang]
+        if builder.lang is not None:
+            cmd += ["-l", builder.lang]
         cmd += builder.cuneiform_args
         cmd += ["-o", output_file.name]
         cmd += ["-"]  # stdin

--- a/src/pyocr/libtesseract/__init__.py
+++ b/src/pyocr/libtesseract/__init__.py
@@ -94,7 +94,8 @@ def image_to_string(image, lang=None, builder=None):
         )
 
         tesseract_raw.set_image(handle, image)
-
+        if "digits" in builder.tesseract_configs:
+            tesseract_raw.set_is_numeric(handle, True)
         # XXX(JFlesch): PageIterator and ResultIterator are actually the
         # very same thing. If it changes, we are screwed.
         tesseract_raw.recognize(handle)

--- a/src/pyocr/libtesseract/__init__.py
+++ b/src/pyocr/libtesseract/__init__.py
@@ -155,7 +155,7 @@ def is_available():
     # (seen with Debian stable + Paperwork)
     # not tested with 3.03
     if (version[0] < 3 or
-            (version[0] == 3 and version[1] < 3)):
+            (version[0] == 3 and version[1] < 4)):
         return False
     return True
 

--- a/src/pyocr/libtesseract/__init__.py
+++ b/src/pyocr/libtesseract/__init__.py
@@ -83,16 +83,7 @@ def _tess_box_to_pyocr_box(box):
 def image_to_string(image, lang=None, builder=None):
     if builder is None:
         builder = builders.TextBuilder()
-    if lang is not None: 
-        if builder.lang is not None:
-            raise ValueError(
-                "Language is set twice, for the builder and in image_to_string"
-            )
-        else:
-            builder.set_language(lang)
-    handle = tesseract_raw.init(lang=builder.lang)
-    if builder.numeric_mode is not None:
-        tesseract_raw.set_numeric_mode(handle, builder.numeric_mode)
+    handle = tesseract_raw.init(lang=lang)
 
     lvl_line = tesseract_raw.PageIteratorLevel.TEXTLINE
     lvl_word = tesseract_raw.PageIteratorLevel.WORD
@@ -163,7 +154,7 @@ def is_available():
     # (seen with Debian stable + Paperwork)
     # not tested with 3.03
     if (version[0] < 3 or
-            (version[0] == 3 and version[1] < 4)):
+            (version[0] == 3 and version[1] < 3)):
         return False
     return True
 
@@ -182,7 +173,7 @@ def get_version():
     
     # cut off "dev" string if exists for proper int conversion
     index = version.find("dev")
-    if index:
+    if index != -1:
         version = version[:index]
 
     version = version.split(".")

--- a/src/pyocr/libtesseract/__init__.py
+++ b/src/pyocr/libtesseract/__init__.py
@@ -83,7 +83,16 @@ def _tess_box_to_pyocr_box(box):
 def image_to_string(image, lang=None, builder=None):
     if builder is None:
         builder = builders.TextBuilder()
-    handle = tesseract_raw.init(lang=lang)
+    if lang is not None: 
+        if builder.lang is not None:
+            raise ValueError(
+                "Language is set twice, for the builder and in image_to_string"
+            )
+        else:
+            builder.set_language(lang)
+    handle = tesseract_raw.init(lang=builder.lang)
+    if builder.numeric_mode is not None:
+        tesseract_raw.set_numeric_mode(handle, builder.numeric_mode)
 
     lvl_line = tesseract_raw.PageIteratorLevel.TEXTLINE
     lvl_word = tesseract_raw.PageIteratorLevel.WORD

--- a/src/pyocr/libtesseract/tesseract_raw.py
+++ b/src/pyocr/libtesseract/tesseract_raw.py
@@ -339,7 +339,7 @@ def set_is_numeric(handle, mode):
     assert(g_libtesseract)
 
     if mode:
-        wl = b"0123456789"
+        wl = b"0123456789."
     else:
         wl = b""
 

--- a/src/pyocr/libtesseract/tesseract_raw.py
+++ b/src/pyocr/libtesseract/tesseract_raw.py
@@ -334,6 +334,17 @@ def get_available_languages(handle):
     return langs
 
 
+def set_numeric_mode(handle, mode):
+    global g_libtesseract
+    assert(g_libtesseract)
+
+    g_libtesseract.TessBaseAPISetVariable(
+        ctypes.c_void_p(handle), 
+        ctypes.c_wchar_p("classify_bln_numeric_mode"),
+        ctypes.c_bool(mode)
+    )
+
+
 def set_page_seg_mode(handle, mode):
     global g_libtesseract
     assert(g_libtesseract)

--- a/src/pyocr/libtesseract/tesseract_raw.py
+++ b/src/pyocr/libtesseract/tesseract_raw.py
@@ -334,14 +334,19 @@ def get_available_languages(handle):
     return langs
 
 
-def set_numeric_mode(handle, mode):
+def set_is_numeric(handle, mode):
     global g_libtesseract
     assert(g_libtesseract)
 
+    if mode:
+        wl = b"0123456789"
+    else:
+        wl = b""
+
     g_libtesseract.TessBaseAPISetVariable(
-        ctypes.c_void_p(handle), 
-        ctypes.c_wchar_p("classify_bln_numeric_mode"),
-        ctypes.c_bool(mode)
+        ctypes.c_void_p(handle),
+        b"tessedit_char_whitelist",
+        wl
     )
 
 

--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -25,7 +25,7 @@ import tempfile
 
 from . import builders
 from . import util
-from pyocr.builders import DigitBuilder
+from pyocr.builders import DigitBuilder  # backward compatibility
 
 # CHANGE THIS IF TESSERACT IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY
 TESSERACT_CMD = 'tesseract.exe' if os.name == 'nt' else 'tesseract'
@@ -61,10 +61,9 @@ class CharBoxBuilder(builders.BaseBuilder):
     def __init__(self):
         file_ext = ["box"]
         tess_conf = ["batch.nochop", "makebox"]
-        cun_arg = []
-        super(CharBoxBuilder, self).__init__(file_ext, tess_conf, cun_arg)
+        cun_args = []
+        super(CharBoxBuilder, self).__init__(file_ext, tess_conf, cun_args)
         self.tesseract_layout = 1
-        self.chars = [] # try to make this builder work with libtesseract
 
     @staticmethod
     def read_file(file_descriptor):
@@ -215,7 +214,7 @@ def get_available_builders():
         builders.TextBuilder,
         builders.WordBoxBuilder,
         CharBoxBuilder,
-        DigitBuilder,
+        builders.DigitBuilder,
     ]
 
 

--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -316,8 +316,8 @@ def image_to_string(image, lang=None, builder=None):
     read, and the temporary files are erased.
 
     Arguments:
-        image --- image to OCR
-        lang --- tesseract language to use. 
+        image --- image to OCR.
+        lang --- tesseract language to use.
         builder --- builder used to configure Tesseract and read its result.
             The builder is used to specify the type of output expected.
             Possible builders are TextBuilder or CharBoxBuilder. If builder ==

--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -25,6 +25,7 @@ import tempfile
 
 from . import builders
 from . import util
+from pyocr.builders import DigitBuilder
 
 # CHANGE THIS IF TESSERACT IS NOT IN YOUR PATH, OR IS NAMED DIFFERENTLY
 TESSERACT_CMD = 'tesseract.exe' if os.name == 'nt' else 'tesseract'
@@ -49,7 +50,7 @@ __all__ = [
 ]
 
 
-class CharBoxBuilder(builders.BaseBuilder):
+class CharBoxBuilder(object):
     """
     If passed to image_to_string(), image_to_string() will return an array of
     Box. Each box correspond to a character recognized in the image.
@@ -98,26 +99,6 @@ class CharBoxBuilder(builders.BaseBuilder):
     @staticmethod
     def __str__():
         return "Character boxes"
-
-
-class DigitBuilder(builders.TextBuilder):
-    """
-    If passed to image_to_string(), image_to_string() will return a string with
-    only digits. Characters recognition will consider text as if it will only
-    composed by digits.
-
-    Pending deprecation, as any builder can now be passed num_mode=True 
-    for the same behaviour (with the appropriate tool).
-
-    """
-
-    @staticmethod
-    def __str__():
-        return "Digits only"
-
-    def __init__(self, tesseract_layout=3):
-        super(DigitBuilder, self).__init__(tesseract_layout)
-        self.tesseract_configs.append("digits")
 
 
 def _set_environment():

--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -59,9 +59,6 @@ class CharBoxBuilder(object):
     file_extensions = ["box"]
     tesseract_configs = ['batch.nochop', 'makebox']
 
-    def __init__(self, lang=None):
-        super(CharBoxBuilder, self).__init__(lang, num_mode=True)
-
     @staticmethod
     def read_file(file_descriptor):
         """
@@ -314,7 +311,6 @@ def image_to_string(image, lang=None, builder=None):
 
     if builder is None:
         builder = builders.TextBuilder()
-    
     with temp_file(".bmp") as input_file:
         with temp_file('') as output_file:
             output_file_name_base = output_file.name

--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -115,7 +115,7 @@ class DigitBuilder(builders.TextBuilder):
     def __str__():
         return "Digits only"
 
-    def __init__(self, tesseract_layout=3, lang=None, ):
+    def __init__(self, tesseract_layout=3):
         super(DigitBuilder, self).__init__(tesseract_layout)
         self.tesseract_configs.append("digits")
 
@@ -321,7 +321,6 @@ def image_to_string(image, lang=None, builder=None):
     Arguments:
         image --- image to OCR
         lang --- tesseract language to use. 
-            Pending deprecation, prefer specifying at builder instantiation.
         builder --- builder used to configure Tesseract and read its result.
             The builder is used to specify the type of output expected.
             Possible builders are TextBuilder or CharBoxBuilder. If builder ==
@@ -334,15 +333,6 @@ def image_to_string(image, lang=None, builder=None):
 
     if builder is None:
         builder = builders.TextBuilder()
-    if lang is not None:
-        if builder.lang is not None:
-            raise ValueError(
-                "Language is set twice, for the builder and in image_to_string"
-            )
-        else:
-            builder.set_language(lang)
-    if builder.numeric_mode:
-        builder.tesseract_configs.append("digits")
     
     with temp_file(".bmp") as input_file:
         with temp_file('') as output_file:
@@ -353,7 +343,7 @@ def image_to_string(image, lang=None, builder=None):
         image.save(input_file.name)
         (status, errors) = run_tesseract(input_file.name,
                                          output_file_name_base,
-                                         lang=builder.lang,
+                                         lang=lang,
                                          configs=builder.tesseract_configs)
         if status:
             raise TesseractError(status, errors)

--- a/src/pyocr/tesseract.py
+++ b/src/pyocr/tesseract.py
@@ -50,14 +50,19 @@ __all__ = [
 ]
 
 
-class CharBoxBuilder(object):
+class CharBoxBuilder(builders.BaseBuilder):
     """
     If passed to image_to_string(), image_to_string() will return an array of
     Box. Each box correspond to a character recognized in the image.
     """
 
-    file_extensions = ["box"]
-    tesseract_configs = ['batch.nochop', 'makebox']
+    def __init__(self):
+        file_ext = ["box"]
+        tess_conf = ["batch.nochop", "makebox"]
+        cun_arg = []
+        super(CharBoxBuilder, self).__init__(file_ext, tess_conf, cun_arg)
+        self.tesseract_layout = 1
+        self.chars = [] # try to make this builder work with libtesseract
 
     @staticmethod
     def read_file(file_descriptor):

--- a/tests/tests_base.py
+++ b/tests/tests_base.py
@@ -1,0 +1,125 @@
+import codecs
+from PIL import Image
+import sys
+sys.path = ["src"] + sys.path
+
+from pyocr import builders
+from pyocr import tesseract
+
+
+class BaseTest(object):
+    tool = None
+
+    def _path_to_img(self, image_file):
+        raise NotImplementedError("Implement in subclasses.")
+
+    def _path_to_out(self, expected_output_file):
+        raise NotImplementedError("Implement in subclasses.")
+
+    def _read_from_expected(self, expected_output_path):
+        raise NotImplementedError("Implement in subclasses.")
+
+    def _read_from_img(self, image_path, lang=None):
+        return self.tool.image_to_string(
+            Image.open(image_path),
+            lang=lang,
+            builder=self._builder
+        )
+
+    def _test_equal(self, output, expected_output):
+        raise NotImplementedError("Implement in subclasses.")
+
+    def set_builder(self):
+        raise NotImplementedError("Implemented in subclasses.")
+
+    def setUp(self):
+        self.set_builder()
+
+    def _test_txt(self, image_file, expected_output_file, lang='eng'):
+        image_path = self._path_to_img(image_file)
+        expected_output_path = self._path_to_out(expected_output_file)
+        
+        expected_output = self._read_from_expected(expected_output_path)
+        output = self._read_from_img(image_path, lang)
+
+        self._test_equal(output, expected_output)
+
+
+class BaseTestText(BaseTest):
+    def set_builder(self):
+        self._builder = builders.TextBuilder()
+
+    def _read_from_expected(self, expected_output_path):
+        expected_output = ""
+        with codecs.open(expected_output_path, 'r', encoding='utf-8') \
+                as file_descriptor:
+            for line in file_descriptor:
+                expected_output += line
+        return expected_output.strip()
+
+    def _test_equal(self, output, expected_output):
+        self.assertEqual(output, expected_output)
+
+
+class BaseTestDigit(BaseTestText):
+    def set_builder(self):
+        self._builder = builders.DigitBuilder()
+
+
+class BaseTestBox(BaseTest):
+    def _read_from_expected(self, expected_output_path):
+        with codecs.open(expected_output_path, 'r', encoding='utf-8') \
+                as file_descriptor:
+            expected_boxes = self._builder.read_file(file_descriptor)
+        expected_boxes.sort()
+
+        return expected_boxes
+
+    def _read_from_img(self, image_path, lang=None):
+        boxes = tesseract.image_to_string(
+            Image.open(image_path), 
+            lang=lang,
+            builder=self._builder
+        )
+        boxes.sort()
+
+        return boxes
+
+
+class BaseTestWordBox(BaseTestBox):
+    def set_builder(self):
+        self._builder = builders.WordBoxBuilder()
+
+    def _test_equal(self, output, expected_output):
+        self.assertTrue(len(output) > 0)
+        self.assertEqual(len(output), len(expected_output))
+
+        for i in range(0, min(len(output), len(expected_output))):
+            try:
+                # python 2.7
+                self.assertEqual(type(expected_output[i].content), unicode)
+                self.assertEqual(type(output[i].content), unicode)
+            except NameError:
+                # python 3
+                self.assertEqual(type(expected_output[i].content), str)
+                self.assertEqual(type(output[i].content), str)
+            self.assertEqual(output[i], expected_output[i])
+
+
+class BaseTestLineBox(BaseTestBox):
+    def set_builder(self):
+        self._builder = builders.LineBoxBuilder()
+
+
+    def _test_equal(self, output, expected_output):
+        self.assertEqual(len(output), len(expected_output))
+
+        for i in range(0, min(len(output), len(expected_output))):
+            for j in range(0, len(output[i].word_boxes)):
+                self.assertEqual(type(output[i].word_boxes[j]),
+                                 type(expected_output[i].word_boxes[j]))
+            self.assertEqual(output[i], expected_output[i])
+
+class BaseTestDigitLineBox(BaseTestLineBox):
+    def set_builder(self):
+        self._builder = builders.DigitLineBoxBuilder()

--- a/tests/tests_base.py
+++ b/tests/tests_base.py
@@ -110,7 +110,6 @@ class BaseTestLineBox(BaseTestBox):
     def set_builder(self):
         self._builder = builders.LineBoxBuilder()
 
-
     def _test_equal(self, output, expected_output):
         self.assertEqual(len(output), len(expected_output))
 

--- a/tests/tests_base.py
+++ b/tests/tests_base.py
@@ -3,6 +3,8 @@ from PIL import Image
 import sys
 sys.path = ["src"] + sys.path
 
+import six
+
 from pyocr import builders
 from pyocr import tesseract
 
@@ -50,12 +52,9 @@ class BaseTestText(BaseTest):
         self._builder = builders.TextBuilder()
 
     def _read_from_expected(self, expected_output_path):
-        expected_output = ""
         with codecs.open(expected_output_path, 'r', encoding='utf-8') \
                 as file_descriptor:
-            for line in file_descriptor:
-                expected_output += line
-        return expected_output.strip()
+            return file_descriptor.read().strip()
 
     def _test_equal(self, output, expected_output):
         self.assertEqual(output, expected_output)
@@ -95,14 +94,8 @@ class BaseTestWordBox(BaseTestBox):
         self.assertEqual(len(output), len(expected_output))
 
         for i in range(0, min(len(output), len(expected_output))):
-            try:
-                # python 2.7
-                self.assertEqual(type(expected_output[i].content), unicode)
-                self.assertEqual(type(output[i].content), unicode)
-            except NameError:
-                # python 3
-                self.assertEqual(type(expected_output[i].content), str)
-                self.assertEqual(type(output[i].content), str)
+            self.assertTrue(isinstance(expected_output[i].content, six.text_type))
+            self.assertTrue(isinstance(output[i].content, six.text_type))
             self.assertEqual(output[i], expected_output[i])
 
 
@@ -118,6 +111,7 @@ class BaseTestLineBox(BaseTestBox):
                 self.assertEqual(type(output[i].word_boxes[j]),
                                  type(expected_output[i].word_boxes[j]))
             self.assertEqual(output[i], expected_output[i])
+
 
 class BaseTestDigitLineBox(BaseTestLineBox):
     def set_builder(self):

--- a/tests/tests_libtesseract.py
+++ b/tests/tests_libtesseract.py
@@ -1,14 +1,12 @@
 import codecs
-from PIL import Image
 import os
-import sys
-sys.path = ["src"] + sys.path
 import tempfile
 
 import unittest
 
 from pyocr import builders
 from pyocr import libtesseract
+from . import tests_base as base
 
 
 class TestContext(unittest.TestCase):
@@ -50,107 +48,65 @@ class TestContext(unittest.TestCase):
         pass
 
 
-class TestTxt(unittest.TestCase):
+class BaseLibtesseract(base.BaseTest):
+    tool = libtesseract
+
+    def _path_to_img(self, image_file):
+        return os.path.join(
+            "tests", "input", "specific", image_file
+        )
+
+    def _path_to_out(self, expected_output_file):
+        return os.path.join(
+            "tests", "output", "specific", "libtesseract", expected_output_file
+        )
+
+
+class TestTxt(base.BaseTestText, BaseLibtesseract, unittest.TestCase):
     """
     These tests make sure the "usual" OCR works fine. (the one generating
     a .txt file)
     """
-    def setUp(self):
-        pass
-
-    def __test_txt(self, image_file, expected_output_file, lang='eng'):
-        image_file = os.path.join(
-            "tests", "input", "specific", image_file
-        )
-        expected_output_file = os.path.join(
-            "tests", "output", "specific", "libtesseract", expected_output_file
-        )
-
-        expected_output = ""
-        with codecs.open(expected_output_file, 'r', encoding='utf-8') \
-                as file_descriptor:
-            for line in file_descriptor:
-                expected_output += line
-        expected_output = expected_output.strip()
-
-        output = libtesseract.image_to_string(
-            Image.open(image_file), lang=lang
-        )
-
-        self.assertEqual(output, expected_output)
-
     def test_basic(self):
-        self.__test_txt('test.png', 'test.txt')
+        self._test_txt('test.png', 'test.txt')
 
     def test_european(self):
-        self.__test_txt('test-european.jpg', 'test-european.txt')
+        self._test_txt('test-european.jpg', 'test-european.txt')
 
     def test_french(self):
-        self.__test_txt('test-french.jpg', 'test-french.txt', 'fra')
+        self._test_txt('test-french.jpg', 'test-french.txt', 'fra')
 
     def test_japanese(self):
-        self.__test_txt('test-japanese.jpg', 'test-japanese.txt', 'jpn')
-
-    def tearDown(self):
-        pass
+        self._test_txt('test-japanese.jpg', 'test-japanese.txt', 'jpn')
 
 
-class TestWordBox(unittest.TestCase):
+class TestDigit(base.BaseTestDigit, BaseLibtesseract, unittest.TestCase):
+    """
+    These tests make sure that Tesseract digits handling works fine.
+    """
+    def test_digits(self):
+        self._test_txt('test-digits.png', 'test-digits.txt')
+
+
+class TestWordBox(base.BaseTestWordBox, BaseLibtesseract, unittest.TestCase):
     """
     These tests make sure that Tesseract box handling works fine.
     """
-    def setUp(self):
-        self.builder = builders.WordBoxBuilder()
-
-    def __test_txt(self, image_file, expected_box_file, lang='eng'):
-        image_file = os.path.join(
-            "tests", "input", "specific", image_file
-        )
-        expected_box_file = os.path.join(
-            "tests", "output", "specific", "libtesseract", expected_box_file
-        )
-
-        with codecs.open(expected_box_file, 'r', encoding='utf-8') \
-                as file_descriptor:
-            expected_boxes = self.builder.read_file(file_descriptor)
-        expected_boxes.sort()
-
-        boxes = libtesseract.image_to_string(
-            Image.open(image_file), lang=lang, builder=self.builder
-        )
-        boxes.sort()
-
-        self.assertTrue(len(boxes) > 0)
-        self.assertEqual(len(boxes), len(expected_boxes))
-
-        for i in range(0, min(len(boxes), len(expected_boxes))):
-            try:
-                # python 2.7
-                self.assertEqual(type(expected_boxes[i].content), unicode)
-                self.assertEqual(type(boxes[i].content), unicode)
-            except NameError:
-                # python 3
-                self.assertEqual(type(expected_boxes[i].content), str)
-                self.assertEqual(type(boxes[i].content), str)
-            self.assertEqual(boxes[i], expected_boxes[i])
-
     def test_basic(self):
-        self.__test_txt('test.png', 'test.words')
+        self._test_txt('test.png', 'test.words')
 
     def test_european(self):
-        self.__test_txt('test-european.jpg', 'test-european.words')
+        self._test_txt('test-european.jpg', 'test-european.words')
 
     def test_french(self):
-        self.__test_txt('test-french.jpg', 'test-french.words', 'fra')
+        self._test_txt('test-french.jpg', 'test-french.words', 'fra')
 
     def test_japanese(self):
-        self.__test_txt('test-japanese.jpg', 'test-japanese.words', 'jpn')
+        self._test_txt('test-japanese.jpg', 'test-japanese.words', 'jpn')
 
     def test_write_read(self):
-        original_boxes = libtesseract.image_to_string(
-            Image.open(os.path.join("tests", "input", "specific", "test.png")),
-            builder=self.builder
-        )
+        image_path = self._path_to_img("test.png")
+        original_boxes = self._read_from_img(image_path)
         self.assertTrue(len(original_boxes) > 0)
 
         (file_descriptor, tmp_path) = tempfile.mkstemp()
@@ -159,10 +115,10 @@ class TestWordBox(unittest.TestCase):
             os.close(file_descriptor)
 
             with codecs.open(tmp_path, 'w', encoding='utf-8') as fdescriptor:
-                self.builder.write_file(fdescriptor, original_boxes)
+                self._builder.write_file(fdescriptor, original_boxes)
 
             with codecs.open(tmp_path, 'r', encoding='utf-8') as fdescriptor:
-                new_boxes = self.builder.read_file(fdescriptor)
+                new_boxes = self._builder.read_file(fdescriptor)
 
             self.assertEqual(len(new_boxes), len(original_boxes))
             for i in range(0, len(original_boxes)):
@@ -170,61 +126,26 @@ class TestWordBox(unittest.TestCase):
         finally:
             os.remove(tmp_path)
 
-    def tearDown(self):
-        pass
 
-
-class TestLineBox(unittest.TestCase):
+class TestLineBox(base.BaseTestLineBox, BaseLibtesseract, unittest.TestCase):
     """
     These tests make sure that Tesseract box handling works fine.
     """
-    def setUp(self):
-        self.builder = builders.LineBoxBuilder()
-
-    def __test_txt(self, image_file, expected_box_file, lang='eng'):
-        image_file = os.path.join(
-            "tests", "input", "specific", image_file
-        )
-        expected_box_file = os.path.join(
-            "tests", "output", "specific", "libtesseract", expected_box_file
-        )
-
-        boxes = libtesseract.image_to_string(
-            Image.open(image_file), lang=lang,
-            builder=self.builder
-        )
-        boxes.sort()
-
-        with codecs.open(expected_box_file, 'r', encoding='utf-8') \
-                as file_descriptor:
-            expected_boxes = self.builder.read_file(file_descriptor)
-        expected_boxes.sort()
-
-        self.assertEqual(len(boxes), len(expected_boxes))
-
-        for i in range(0, min(len(boxes), len(expected_boxes))):
-            for j in range(0, len(boxes[i].word_boxes)):
-                self.assertEqual(type(boxes[i].word_boxes[j]),
-                                 type(expected_boxes[i].word_boxes[j]))
-            self.assertEqual(boxes[i], expected_boxes[i])
-
     def test_basic(self):
-        self.__test_txt('test.png', 'test.lines')
+        self._test_txt('test.png', 'test.lines')
 
     def test_european(self):
-        self.__test_txt('test-european.jpg', 'test-european.lines')
+        self._test_txt('test-european.jpg', 'test-european.lines')
 
     def test_french(self):
-        self.__test_txt('test-french.jpg', 'test-french.lines', 'fra')
+        self._test_txt('test-french.jpg', 'test-french.lines', 'fra')
 
     def test_japanese(self):
-        self.__test_txt('test-japanese.jpg', 'test-japanese.lines', 'jpn')
+        self._test_txt('test-japanese.jpg', 'test-japanese.lines', 'jpn')
 
     def test_write_read(self):
-        original_boxes = libtesseract.image_to_string(
-            Image.open(os.path.join("tests", "input", "specific", "test.png")),
-            builder=self.builder
-        )
+        image_path = self._path_to_img("test.png")
+        original_boxes = self._read_from_img(image_path)
         self.assertTrue(len(original_boxes) > 0)
 
         (file_descriptor, tmp_path) = tempfile.mkstemp()
@@ -233,10 +154,10 @@ class TestLineBox(unittest.TestCase):
             os.close(file_descriptor)
 
             with codecs.open(tmp_path, 'w', encoding='utf-8') as fdescriptor:
-                self.builder.write_file(fdescriptor, original_boxes)
+                self._builder.write_file(fdescriptor, original_boxes)
 
             with codecs.open(tmp_path, 'r', encoding='utf-8') as fdescriptor:
-                new_boxes = self.builder.read_file(fdescriptor)
+                new_boxes = self._builder.read_file(fdescriptor)
 
             self.assertEqual(len(new_boxes), len(original_boxes))
             for i in range(0, len(original_boxes)):
@@ -244,65 +165,49 @@ class TestLineBox(unittest.TestCase):
         finally:
             os.remove(tmp_path)
 
-    def tearDown(self):
-        pass
+
+class TestDigitLineBox(base.BaseTestDigitLineBox, BaseLibtesseract, 
+                       unittest.TestCase):
+    def test_digits(self):
+        self._test_txt('test-digits.png', 'test-digits.lines')
 
 
-class TestOrientation(unittest.TestCase):
+class TestOrientation(BaseLibtesseract, unittest.TestCase):
+    def set_builder(self):
+        self._builder = builders.TextBuilder()
+
     def test_can_detect_orientation(self):
         self.assertTrue(libtesseract.can_detect_orientation())
 
     def test_orientation_0(self):
-        img = Image.open(os.path.join('tests', 'input', 'specific', 'test.png'))
+        img = base.Image.open(self._path_to_img("test.png"))
         result = libtesseract.detect_orientation(img, lang='eng')
         self.assertEqual(result['angle'], 0)
 
     def test_orientation_90(self):
-        img = Image.open(os.path.join('tests', 'input', 'specific',
-                                      'test-90.png'))
+        img = base.Image.open(self._path_to_img("test-90.png"))
         result = libtesseract.detect_orientation(img, lang='eng')
         self.assertEqual(result['angle'], 90)
 
 
-class TestBasicDoc(unittest.TestCase):
+class TestBasicDoc(base.BaseTestLineBox, unittest.TestCase):
     """
     These tests make sure that Tesseract box handling works fine.
     """
-    def setUp(self):
-        self.builder = builders.LineBoxBuilder()
+    tool = libtesseract
 
-    def __test_txt(self, expected_output_file, lang='eng'):
-        image_file = os.path.join(
-            "tests", "input", "real", "basic_doc.jpg"
+    def _path_to_img(self, image_file):
+        return os.path.join(
+            "tests", "input", "real", image_file
         )
-        expected_output_file = os.path.join(
+
+    def _path_to_out(self, expected_output_file):
+        return os.path.join(
             "tests", "output", "real", "libtesseract", expected_output_file
         )
 
-        output = libtesseract.image_to_string(
-            Image.open(image_file), lang=lang,
-            builder=self.builder
-        )
-        output.sort()
-
-        with codecs.open(expected_output_file, 'r', encoding='utf-8') \
-                as file_descriptor:
-            expected_output = self.builder.read_file(file_descriptor)
-        expected_output.sort()
-
-        self.assertEqual(len(output), len(expected_output))
-
-        for i in range(0, min(len(output), len(expected_output))):
-            for j in range(0, len(output[i].word_boxes)):
-                self.assertEqual(type(output[i].word_boxes[j]),
-                                 type(expected_output[i].word_boxes[j]))
-            self.assertEqual(output[i], expected_output[i])
-
     def test_basic(self):
-        self.__test_txt('basic_doc.lines')
-
-    def tearDown(self):
-        pass
+        self._test_txt('basic_doc.jpg', 'basic_doc.lines')
 
 
 def get_all_tests():
@@ -334,6 +239,14 @@ def get_all_tests():
     tests = unittest.TestSuite(map(TestWordBox, test_names))
     all_tests.addTest(tests)
     tests = unittest.TestSuite(map(TestLineBox, test_names))
+    all_tests.addTest(tests)
+
+    test_names = [
+        'test_digits'
+    ]
+    tests = unittest.TestSuite(map(TestDigit, test_names))
+    all_tests.addTest(tests)
+    tests = unittest.TestSuite(map(TestDigitLineBox, test_names))
     all_tests.addTest(tests)
 
     test_names = [

--- a/tests/tests_libtesseract.py
+++ b/tests/tests_libtesseract.py
@@ -29,6 +29,7 @@ class TestContext(unittest.TestCase):
             (3, 2, 2),
             (3, 3, 0),
             (3, 4, 0),
+            (3, 4, 1),
         ), ("Tesseract does not have the expected version"
             " (3.4.0) ! Some tests will be skipped !"))
 

--- a/tests/tests_tesseract.py
+++ b/tests/tests_tesseract.py
@@ -1,14 +1,12 @@
-import codecs
-from PIL import Image
 import os
-import sys
-sys.path = ["src"] + sys.path
+import codecs
 import tempfile
 
 import unittest
 
 from pyocr import builders
 from pyocr import tesseract
+from . import tests_base as base
 
 
 class TestContext(unittest.TestCase):
@@ -48,91 +46,66 @@ class TestContext(unittest.TestCase):
         pass
 
 
-class TestTxt(unittest.TestCase):
+class BaseTesseract(base.BaseTest):
+    tool = tesseract
+
+    def _path_to_img(self, image_file):
+        return os.path.join(
+            "tests", "input", "specific", image_file
+        )
+
+    def _path_to_out(self, expected_output_file):
+        return os.path.join(
+            "tests", "output", "specific", "tesseract", expected_output_file
+        )
+
+
+class TestTxt(base.BaseTestText, BaseTesseract, unittest.TestCase):
     """
     These tests make sure the "usual" OCR works fine. (the one generating
     a .txt file)
     """
-    def setUp(self):
-        pass
-
-    def __test_txt(self, image_file, expected_output_file, lang='eng'):
-        image_file = os.path.join("tests", "input", "specific", image_file)
-        expected_output_file = os.path.join(
-            "tests", "output", "specific", "tesseract", expected_output_file
-        )
-
-        expected_output = ""
-        with codecs.open(expected_output_file, 'r', encoding='utf-8') \
-                as file_descriptor:
-            for line in file_descriptor:
-                expected_output += line
-        expected_output = expected_output.strip()
-
-        output = tesseract.image_to_string(Image.open(image_file), lang=lang)
-
-        self.assertEqual(output, expected_output)
-
     def test_basic(self):
-        self.__test_txt('test.png', 'test.txt')
+        self._test_txt('test.png', 'test.txt')
 
     def test_european(self):
-        self.__test_txt('test-european.jpg', 'test-european.txt')
+        self._test_txt('test-european.jpg', 'test-european.txt')
 
     def test_french(self):
-        self.__test_txt('test-french.jpg', 'test-french.txt', 'fra')
+        self._test_txt('test-french.jpg', 'test-french.txt', 'fra')
 
     def test_japanese(self):
-        self.__test_txt('test-japanese.jpg', 'test-japanese.txt', 'jpn')
-
-    def tearDown(self):
-        pass
+        self._test_txt('test-japanese.jpg', 'test-japanese.txt', 'jpn')
 
 
-class TestCharBox(unittest.TestCase):
+class TestCharBox(base.BaseTestBox, BaseTesseract, unittest.TestCase):
     """
     These tests make sure that Tesseract box handling works fine.
     """
-    def setUp(self):
-        self.builder = tesseract.CharBoxBuilder()
+    def set_builder(self):
+        self._builder = tesseract.CharBoxBuilder()
+    
+    def _test_equal(self, output, expected_output):
+        self.assertEqual(len(output), len(expected_output))
 
-    def __test_txt(self, image_file, expected_box_file, lang='eng'):
-        image_file = os.path.join("tests", "input", "specific", image_file)
-        expected_box_file = os.path.join(
-            "tests", "output", "specific", "tesseract", expected_box_file
-        )
-
-        with codecs.open(expected_box_file, 'r', encoding='utf-8') \
-                as file_descriptor:
-            expected_boxes = self.builder.read_file(file_descriptor)
-        expected_boxes.sort()
-
-        boxes = tesseract.image_to_string(Image.open(image_file), lang=lang,
-                                             builder=self.builder)
-        boxes.sort()
-
-        self.assertEqual(len(boxes), len(expected_boxes))
-
-        for i in range(0, min(len(boxes), len(expected_boxes))):
-            self.assertEqual(boxes[i], expected_boxes[i])
+        for i in range(0, min(len(output), len(expected_output))):
+            self.assertEqual(output[i], expected_output[i])
 
     def test_basic(self):
-        self.__test_txt('test.png', 'test.box')
+        self._test_txt('test.png', 'test.box')
 
     def test_european(self):
-        self.__test_txt('test-european.jpg', 'test-european.box')
+        self._test_txt('test-european.jpg', 'test-european.box')
 
     def test_french(self):
-        self.__test_txt('test-french.jpg', 'test-french.box', 'fra')
+        self._test_txt('test-french.jpg', 'test-french.box', 'fra')
 
     def test_japanese(self):
-        self.__test_txt('test-japanese.jpg', 'test-japanese.box', 'jpn')
+        self._test_txt('test-japanese.jpg', 'test-japanese.box', 'jpn')
 
     def test_write_read(self):
-        original_boxes = tesseract.image_to_string(
-            Image.open(
-                os.path.join("tests", "input", "specific", "test.png")
-            ), builder=self.builder)
+        image_path = self._path_to_img("test.png")
+        original_boxes = self._read_from_img(image_path)
         self.assertTrue(len(original_boxes) > 0)
 
         (file_descriptor, tmp_path) = tempfile.mkstemp()
@@ -141,10 +114,10 @@ class TestCharBox(unittest.TestCase):
             os.close(file_descriptor)
 
             with codecs.open(tmp_path, 'w', encoding='utf-8') as fdescriptor:
-                self.builder.write_file(fdescriptor, original_boxes)
+                self._builder.write_file(fdescriptor, original_boxes)
 
             with codecs.open(tmp_path, 'r', encoding='utf-8') as fdescriptor:
-                new_boxes = self.builder.read_file(fdescriptor)
+                new_boxes = self._builder.read_file(fdescriptor)
 
             self.assertEqual(len(new_boxes), len(original_boxes))
             for i in range(0, len(original_boxes)):
@@ -152,92 +125,34 @@ class TestCharBox(unittest.TestCase):
         finally:
             os.remove(tmp_path)
 
-    def tearDown(self):
-        pass
 
-
-class TestDigits(unittest.TestCase):
+class TestDigit(base.BaseTestDigit, BaseTesseract, unittest.TestCase):
     """
     These tests make sure that Tesseract digits handling works fine.
     """
-    def setUp(self):
-        self.builder = tesseract.DigitBuilder()
-
-    def __test_text(self, image_file, expected_output_file, lang='eng'):
-        image_file = os.path.join("tests", "input", "specific", image_file)
-        expected_output_file = os.path.join(
-            "tests", "output", "specific", "tesseract", expected_output_file
-        )
-
-        expected_output = ""
-        with codecs.open(expected_output_file, 'r', encoding='utf-8') \
-                as file_descriptor:
-            for line in file_descriptor:
-                expected_output += line
-        expected_output = expected_output.strip()
-
-        output = tesseract.image_to_string(Image.open(image_file), lang=lang,
-                                              builder=self.builder)
-
-        self.assertEqual(output, expected_output)
-
     def test_digits(self):
-        self.__test_text('test-digits.png', 'test-digits.txt')
+        self._test_txt('test-digits.png', 'test-digits.txt')
 
 
-class TestWordBox(unittest.TestCase):
+class TestWordBox(base.BaseTestWordBox, BaseTesseract, unittest.TestCase):
     """
     These tests make sure that Tesseract box handling works fine.
     """
-    def setUp(self):
-        self.builder = builders.WordBoxBuilder()
-
-    def __test_txt(self, image_file, expected_box_file, lang='eng'):
-        image_file = os.path.join("tests", "input", "specific", image_file)
-        expected_box_file = os.path.join(
-            "tests", "output", "specific", "tesseract", expected_box_file
-        )
-
-        with codecs.open(expected_box_file, 'r', encoding='utf-8') \
-                as file_descriptor:
-            expected_boxes = self.builder.read_file(file_descriptor)
-        expected_boxes.sort()
-
-        boxes = tesseract.image_to_string(Image.open(image_file), lang=lang,
-                                             builder=self.builder)
-        boxes.sort()
-
-        self.assertTrue(len(boxes) > 0)
-        self.assertEqual(len(boxes), len(expected_boxes))
-
-        for i in range(0, min(len(boxes), len(expected_boxes))):
-            try:
-                # python 2.7
-                self.assertEqual(type(expected_boxes[i].content), unicode)
-                self.assertEqual(type(boxes[i].content), unicode)
-            except NameError:
-                # python 3
-                self.assertEqual(type(expected_boxes[i].content), str)
-                self.assertEqual(type(boxes[i].content), str)
-            self.assertEqual(boxes[i], expected_boxes[i])
-
     def test_basic(self):
-        self.__test_txt('test.png', 'test.words')
+        self._test_txt('test.png', 'test.words')
 
     def test_european(self):
-        self.__test_txt('test-european.jpg', 'test-european.words')
+        self._test_txt('test-european.jpg', 'test-european.words')
 
     def test_french(self):
-        self.__test_txt('test-french.jpg', 'test-french.words', 'fra')
+        self._test_txt('test-french.jpg', 'test-french.words', 'fra')
 
     def test_japanese(self):
-        self.__test_txt('test-japanese.jpg', 'test-japanese.words', 'jpn')
+        self._test_txt('test-japanese.jpg', 'test-japanese.words', 'jpn')
 
     def test_write_read(self):
-        original_boxes = tesseract.image_to_string(
-            Image.open(
-                os.path.join("tests", "input", "specific", "test.png")
-            ), builder=self.builder)
+        image_path = self._path_to_img("test.png")
+        original_boxes = self._read_from_img(image_path)
         self.assertTrue(len(original_boxes) > 0)
 
         (file_descriptor, tmp_path) = tempfile.mkstemp()
@@ -246,10 +161,50 @@ class TestWordBox(unittest.TestCase):
             os.close(file_descriptor)
 
             with codecs.open(tmp_path, 'w', encoding='utf-8') as fdescriptor:
-                self.builder.write_file(fdescriptor, original_boxes)
+                self._builder.write_file(fdescriptor, original_boxes)
 
             with codecs.open(tmp_path, 'r', encoding='utf-8') as fdescriptor:
-                new_boxes = self.builder.read_file(fdescriptor)
+                new_boxes = self._builder.read_file(fdescriptor)
+
+            self.assertEqual(len(new_boxes), len(original_boxes))
+            for i in range(0, len(original_boxes)):
+                self.assertEqual(new_boxes[i], original_boxes[i])
+        finally:
+            os.remove(tmp_path)
+
+
+class TestLineBox(base.BaseTestLineBox, BaseTesseract, unittest.TestCase):
+    """
+    These tests make sure that Tesseract box handling works fine.
+
+    """
+    def test_basic(self):
+        self._test_txt('test.png', 'test.lines')
+
+    def test_european(self):
+        self._test_txt('test-european.jpg', 'test-european.lines')
+
+    def test_french(self):
+        self._test_txt('test-french.jpg', 'test-french.lines', 'fra')
+
+    def test_japanese(self):
+        self._test_txt('test-japanese.jpg', 'test-japanese.lines', 'jpn')
+
+    def test_write_read(self):
+        image_path = self._path_to_img("test.png")
+        original_boxes = self._read_from_img(image_path)
+        self.assertTrue(len(original_boxes) > 0)
+
+        (file_descriptor, tmp_path) = tempfile.mkstemp()
+        try:
+            # we must open the file with codecs.open() for utf-8 support
+            os.close(file_descriptor)
+
+            with codecs.open(tmp_path, 'w', encoding='utf-8') as fdescriptor:
+                self._builder.write_file(fdescriptor, original_boxes)
+
+            with codecs.open(tmp_path, 'r', encoding='utf-8') as fdescriptor:
+                new_boxes = self._builder.read_file(fdescriptor)
 
             self.assertEqual(len(new_boxes), len(original_boxes))
             for i in range(0, len(original_boxes)):
@@ -261,88 +216,26 @@ class TestWordBox(unittest.TestCase):
         pass
 
 
-class TestLineBox(unittest.TestCase):
-    """
-    These tests make sure that Tesseract box handling works fine.
-    """
-    def setUp(self):
-        self.builder = builders.LineBoxBuilder()
-
-    def __test_txt(self, image_file, expected_box_file, lang='eng'):
-        image_file = os.path.join("tests", "input", "specific", image_file)
-        expected_box_file = os.path.join(
-            "tests", "output", "specific", "tesseract", expected_box_file
-        )
-
-        boxes = tesseract.image_to_string(Image.open(image_file), lang=lang,
-                                             builder=self.builder)
-        boxes.sort()
-
-        with codecs.open(expected_box_file, 'r', encoding='utf-8') \
-                as file_descriptor:
-            expected_boxes = self.builder.read_file(file_descriptor)
-        expected_boxes.sort()
-
-        self.assertEqual(len(boxes), len(expected_boxes))
-
-        for i in range(0, min(len(boxes), len(expected_boxes))):
-            for j in range(0, len(boxes[i].word_boxes)):
-                self.assertEqual(type(boxes[i].word_boxes[j]),
-                                 type(expected_boxes[i].word_boxes[j]))
-            self.assertEqual(boxes[i], expected_boxes[i])
-
-    def test_basic(self):
-        self.__test_txt('test.png', 'test.lines')
-
-    def test_european(self):
-        self.__test_txt('test-european.jpg', 'test-european.lines')
-
-    def test_french(self):
-        self.__test_txt('test-french.jpg', 'test-french.lines', 'fra')
-
-    def test_japanese(self):
-        self.__test_txt('test-japanese.jpg', 'test-japanese.lines', 'jpn')
-
-    def test_write_read(self):
-        original_boxes = tesseract.image_to_string(
-            Image.open(
-                os.path.join("tests", "input", "specific", "test.png")
-            ),
-            builder=self.builder)
-        self.assertTrue(len(original_boxes) > 0)
-
-        (file_descriptor, tmp_path) = tempfile.mkstemp()
-        try:
-            # we must open the file with codecs.open() for utf-8 support
-            os.close(file_descriptor)
-
-            with codecs.open(tmp_path, 'w', encoding='utf-8') as fdescriptor:
-                self.builder.write_file(fdescriptor, original_boxes)
-
-            with codecs.open(tmp_path, 'r', encoding='utf-8') as fdescriptor:
-                new_boxes = self.builder.read_file(fdescriptor)
-
-            self.assertEqual(len(new_boxes), len(original_boxes))
-            for i in range(0, len(original_boxes)):
-                self.assertEqual(new_boxes[i], original_boxes[i])
-        finally:
-            os.remove(tmp_path)
-
-    def tearDown(self):
-        pass
+class TestDigitLineBox(base.BaseTestDigitLineBox, BaseTesseract, 
+                       unittest.TestCase):
+    def test_digits(self):
+        self._test_txt('test-digits.png', 'test-digits.lines')
 
 
-class TestOrientation(unittest.TestCase):
+class TestOrientation(BaseTesseract, unittest.TestCase):
+    def set_builder(self):
+        self._builder = builders.TextBuilder()
+
     def test_can_detect_orientation(self):
         self.assertTrue(tesseract.can_detect_orientation())
 
     def test_orientation_0(self):
-        img = Image.open(os.path.join("tests", "input", "specific", "test.png"))
+        img = base.Image.open(self._path_to_img("test.png"))
         result = tesseract.detect_orientation(img, lang='eng')
         self.assertEqual(result['angle'], 0)
 
     def test_orientation_90(self):
-        img = Image.open(os.path.join("tests", "input", "specific", "test-90.png"))
+        img = base.Image.open(self._path_to_img("test-90.png"))
         result = tesseract.detect_orientation(img, lang='eng')
         self.assertEqual(result['angle'], 90)
 
@@ -383,7 +276,9 @@ def get_all_tests():
     test_names = [
         'test_digits'
     ]
-    tests = unittest.TestSuite(map(TestDigits, test_names))
+    tests = unittest.TestSuite(map(TestDigit, test_names))
+    all_tests.addTest(tests)
+    tests = unittest.TestSuite(map(TestDigitLineBox, test_names))
     all_tests.addTest(tests)
 
     test_names = [


### PR DESCRIPTION
So this has got a number of changes :
- Builders inherit from `BaseBuilder` (easy to drop if you want to)
- Builders' class attributes become instance attributes
- `DigitBuilder` moved to `builders.py`
- `DigitLineBoxBuilder` for digits inherits from `LineBoxBuilder`
- `libtesseract` is available with version 3.3
- Tests have been restructured to reduce code redundancy.
  Some mixins are defined in `tests/tests_base.py` then multiple inheritance is used for the actual tests.
- Tests have been added for the new builders.
- `test_version` in `tests_libtesseract` passes with version (3,4,1).

On my system (libtesseract3.4.1) most of the tests pass except :
- The cuneiform tests since I don't have it installed
- The libtesseract words and lines japanese tests
- The libtesseract `TestBasicDoc` test
- The line digits test since the files `test-digits.lines` don't exist