### PR TITLE
Add support for Tesseract version 3.05.00

### DIFF
--- a/src/pyocr/builders.py
+++ b/src/pyocr/builders.py
@@ -240,8 +240,10 @@ class BaseBuilder(object):
         cuneiform_args : Arguments passed to the Cuneiform command line.
     """
 
-    def __init__(self, file_extensions, tesseract_configs, cuneiform_args):
+    def __init__(self, file_extensions, tesseract_flags, tesseract_configs,
+                 cuneiform_args):
         self.file_extensions = file_extensions
+        self.tesseract_flags = tesseract_flags
         self.tesseract_configs = tesseract_configs
         self.cuneiform_args = cuneiform_args
 
@@ -298,7 +300,7 @@ class TextBuilder(BaseBuilder):
     def __init__(self, tesseract_layout=3, cuneiform_dotmatrix=False,
                  cuneiform_fax=False, cuneiform_singlecolumn=False):
         file_ext = ["txt"]
-        tess_conf = ["-psm", str(tesseract_layout)]
+        tess_flags = ["-psm", str(tesseract_layout)]
         cun_args = ["-f", "text"]
         # Add custom cuneiform parameters if needed
         for par, arg in [(cuneiform_dotmatrix, "--dotmatrix"),
@@ -306,7 +308,7 @@ class TextBuilder(BaseBuilder):
                          (cuneiform_singlecolumn, "--singlecolumn")]:
             if par:
                 cun_args.append(arg)
-        super(TextBuilder, self).__init__(file_ext, tess_conf, cun_args)
+        super(TextBuilder, self).__init__(file_ext, tess_flags, [], cun_args)
         self.tesseract_layout = tesseract_layout
         self.built_text = []
 
@@ -540,9 +542,11 @@ class WordBoxBuilder(BaseBuilder):
 
     def __init__(self, tesseract_layout=1):
         file_ext = ["html", "hocr"]
-        tess_conf = ["hocr", "-psm", str(tesseract_layout)]
+        tess_flags = ["-psm", str(tesseract_layout)]
+        tess_conf = ["hocr"]
         cun_args = ["-f", "hocr"]
-        super(WordBoxBuilder, self).__init__(file_ext, tess_conf, cun_args)
+        super(WordBoxBuilder, self).__init__(file_ext, tess_flags, tess_conf,
+                                             cun_args)
         self.word_boxes = []
         self.tesseract_layout = tesseract_layout
 
@@ -614,9 +618,11 @@ class LineBoxBuilder(BaseBuilder):
 
     def __init__(self, tesseract_layout=1):
         file_ext = ["html", "hocr"]
-        tess_conf = ["hocr", "-psm", str(tesseract_layout)]
+        tess_flags = ["-psm", str(tesseract_layout)]
+        tess_conf = ["hocr"]
         cun_args = ["-f", "hocr"]
-        super(LineBoxBuilder, self).__init__(file_ext, tess_conf, cun_args)
+        super(LineBoxBuilder, self).__init__(file_ext, tess_flags, tess_conf,
+                                             cun_args)
         self.lines = []
         self.tesseract_layout = tesseract_layout
 

--- a/tests/tests_libtesseract.py
+++ b/tests/tests_libtesseract.py
@@ -33,8 +33,9 @@ class TestContext(unittest.TestCase):
             (3, 3, 0),
             (3, 4, 0),
             (3, 4, 1),
+            (3, 5, 0),
         ), ("Tesseract does not have the expected version"
-            " (3.4.0) ! Some tests will be skipped !"))
+            " (3.5.0) ! Some tests will be skipped !"))
 
     def test_langs(self):
         langs = libtesseract.get_available_languages()

--- a/tests/tests_tesseract.py
+++ b/tests/tests_tesseract.py
@@ -27,8 +27,9 @@ class TestContext(unittest.TestCase):
             (3, 3, 0),
             (3, 4, 0),
             (3, 4, 1),
+            (3, 5, 0),
         ), ("Tesseract does not have the expected version"
-            " (3.4.0) ! Some tests will be skipped !"))
+            " (3.5.0) ! Some tests will be skipped !"))
 
     def test_langs(self):
         langs = tesseract.get_available_languages()


### PR DESCRIPTION
This is a bit more involved, because Tesseract 3.05.00 comes not only with improvements but also with a few quirks we need to deal with.

The first quirk is that the order arguments of the `tesseract` command now matters and the list of configurations has to be at the end of the command line. So we add a new attribute `tesseract_flags` to the `BaseBuilder` class that contains a list of all the flags to pass to `tesseract`, the `tesseract_configs` attribute however remains pretty much the same but now only really contains a list of configs instead of being mixed with flag arguments.

Another quirk has to do with Leptonica >= 1.74 which Tesseract 3.05.00 now requires. Leptonica has special handling of files that reside in `/tmp` and assumes that it's an internal temporary file of Leptonica. In order to deal with it, we now run Tesseract in a temporary directory, which contains the input/output files and use the relative name of these files because Leptonica only searches for path names beginning with `/tmp`.

Fortunately the last item we need to address is not really a quirk, but an API change. In Tesseract 3.05.00 there is now a new function called `TessBaseAPIDetectOrientationScript()`, which doesn't fill the `OSResults` object anymore but now allows to pass the values we're interested in directly by reference. 
We need to use this new function because the old function `TessBaseAPIDetectOS()` now *always* returns `false`.

Ran the test suite successfully with Python 3.5 and both Tesseract 3.04.01 and 3.05.00 except the following tests, which also didn't succeed prior to this commit:

 * `cuneiform:TestTxt.test_basic`
 * `cuneiform:TestTxt.test_european`
 * `cuneiform:TestTxt.test_french`
 * `cuneiform:TestWordBox.test_basic`
 * `cuneiform:TestWordBox.test_european`
 * `cuneiform:TestWordBox.test_french`
 * `libtesseract:TestBasicDoc.test_basic`
 * `libtesseract:TestDigitLineBox.test_digits`
 * `libtesseract:TestLineBox.test_japanese`
 * `libtesseract:TestTxt.test_japanese`
 * `libtesseract:TestWordBox.test_japanese`
 * `tesseract:TestDigitLineBox.test_digits`
 * `tesseract:TestTxt.test_japanese`

The failure of these test cases is probably related to issue #52, but from looking at the failures it doesn't seem to be related to this change anyway.